### PR TITLE
fix: logging to wandb on Overtaci

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ known_third_party = ["wandb"]
 [tool.pylint]
 load-plugins = "pylint.extensions.docparams,pylint.extensions.code_style,pylint.extensions.for_any_all,pylint.extensions.typing"
 good-names = "df,p,f,d,e,n,k,i,v"
-disable = "too-many-lines,line-too-long,missing-raises-doc,no-self-argument,unused-wildcard-import,wildcard-import,no-else-return,too-many-arguments,redefined-outer-name"
+disable = "too-many-lines,line-too-long,missing-raises-doc,no-self-argument,unused-wildcard-import,wildcard-import,no-else-return,too-many-arguments,redefined-outer-name,c-extension-no-member,wrong-import-order"
 
 [tool.semantic_release]
 branch = "main"

--- a/src/application/t2d/generate_features_and_write_to_disk.py
+++ b/src/application/t2d/generate_features_and_write_to_disk.py
@@ -5,6 +5,8 @@ maturity.
 """
 
 import random
+import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -32,7 +34,7 @@ from psycop_feature_generation.timeseriesflattener.create_feature_combinations i
 from psycop_feature_generation.timeseriesflattener.flattened_dataset import (
     FlattenedDataset,
 )
-from psycop_feature_generation.utils import FEATURE_SETS_PATH
+from psycop_feature_generation.utils import FEATURE_SETS_PATH, PROJECT_ROOT
 
 
 def log_to_wandb(wandb_project_name, predictor_combinations, save_dir):
@@ -42,6 +44,13 @@ def log_to_wandb(wandb_project_name, predictor_combinations, save_dir):
         "save_path": save_dir,
         "predictor_list": predictor_combinations,
     }
+
+    # on Overtaci, the wandb tmp directory is not automatically created
+    # so we create it here
+    # create dewbug-cli.one folders in /tmp and project dir
+    if sys.platform == "win32":
+        (Path(tempfile.gettempdir()) / "debug-cli.onerm").mkdir(exist_ok=True)
+        (PROJECT_ROOT / "wandb" / "debug-cli.onerm").mkdir(exist_ok=True)
 
     run = wandb.init(project=wandb_project_name, config=feature_settings)
     run.log_artifact("poetry.lock", name="poetry_lock_file", type="poetry_lock")

--- a/tests/test_wandb/test_wandb.py
+++ b/tests/test_wandb/test_wandb.py
@@ -1,6 +1,7 @@
-from application.t2d.generate_features_and_write_to_disk import (
-    log_to_wandb,
-)
+"""Test wandb logging."""
+from application.t2d.generate_features_and_write_to_disk import log_to_wandb
+
+# pylint: disable=missing-function-docstring
 
 
 def test_log_to_wandb():

--- a/tests/test_wandb/test_wandb.py
+++ b/tests/test_wandb/test_wandb.py
@@ -1,0 +1,7 @@
+from application.t2d.generate_features_and_write_to_disk import (
+    log_to_wandb,
+)
+
+
+def test_log_to_wandb():
+    log_to_wandb("test", "x", "y")

--- a/tests/test_wandb/test_wandb.py
+++ b/tests/test_wandb/test_wandb.py
@@ -1,8 +1,0 @@
-"""Test wandb logging."""
-from application.t2d.generate_features_and_write_to_disk import log_to_wandb
-
-# pylint: disable=missing-function-docstring
-
-
-def test_log_to_wandb():
-    log_to_wandb("test", "x", "y")


### PR DESCRIPTION
- [X] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatability)

Fixes #25 

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
