### PR TITLE
ci: don't allow concurrent test runs on same PR

### DIFF
--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     concurrency: 
-      group: ${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
 
     strategy:

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -19,7 +19,7 @@ jobs:
 
     # This allows a subsequently queued workflow run to interrupt previous runs
     concurrency:
-      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+      group: '${{ github.workflow }} - ${{ matrix.os }} @ ${{ github.ref }}'
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
 
     strategy:
       matrix:

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    concurrency: 
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
 
     strategy:
       matrix:
@@ -19,6 +16,11 @@ jobs:
         python-version: [3.9]
         poetry-version: [1.1.15]
         cache-version: [0.0.2] # Change this number if you want to manually invalidate all caches
+
+    # This allows a subsequently queued workflow run to interrupt previous runs
+    concurrency:
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Saves a bunch of github minutes. These changes imply we might want to centralise the test github actions script. 