### PR TITLE
fix: hardcoded file suffix

### DIFF
--- a/src/psycop_feature_generation/data_checks/flattened/data_integrity.py
+++ b/src/psycop_feature_generation/data_checks/flattened/data_integrity.py
@@ -401,6 +401,8 @@ def save_feature_set_integrity_from_dir(  # noqa pylint: disable=too-many-statem
         out_dir (Optional[Path]): Path to the directory where the reports should be saved
         file_suffix (str, optional): Suffix of the files to load. Must be either "csv" or "parquet".
     """
+    if file_suffix is None:
+        file_suffix = "parquet"
     if file_suffix not in ["parquet", "csv"]:
         raise ValueError(
             f"file_suffix must be either 'parquet' or 'csv', got {file_suffix}",
@@ -421,7 +423,7 @@ def save_feature_set_integrity_from_dir(  # noqa pylint: disable=too-many-statem
         feature_set_dir=feature_set_dir,
         split="train",
         nrows=n_rows,
-        file_suffix="parquet",
+        file_suffix=file_suffix,
     )
 
     failed_checks = (

--- a/src/psycop_feature_generation/data_checks/flattened/data_integrity.py
+++ b/src/psycop_feature_generation/data_checks/flattened/data_integrity.py
@@ -399,7 +399,7 @@ def save_feature_set_integrity_from_dir(  # noqa pylint: disable=too-many-statem
             Should only be used for debugging.
         split_names (list[str]): list of splits to check (train, val, test)
         out_dir (Optional[Path]): Path to the directory where the reports should be saved
-        file_suffix (str, optional): Suffix of the files to load. Must be either "csv" or "parquet".
+        file_suffix (str, optional): Suffix of the files to load. Must be either "csv" or "parquet". Defaults to "parquet".
     """
     if file_suffix not in ["parquet", "csv"]:
         raise ValueError(

--- a/src/psycop_feature_generation/data_checks/flattened/data_integrity.py
+++ b/src/psycop_feature_generation/data_checks/flattened/data_integrity.py
@@ -385,7 +385,7 @@ def save_feature_set_integrity_from_dir(  # noqa pylint: disable=too-many-statem
     n_rows: Optional[int] = None,
     split_names: Optional[list[str]] = None,
     out_dir: Optional[Path] = None,
-    file_suffix: Optional[str] = None,
+    file_suffix: str = "parquet",
 ) -> None:
     """Runs Deepcheck data integrity and train/val/test checks for a given
     directory containing train/val/test files. Splits indicates which data.
@@ -401,8 +401,6 @@ def save_feature_set_integrity_from_dir(  # noqa pylint: disable=too-many-statem
         out_dir (Optional[Path]): Path to the directory where the reports should be saved
         file_suffix (str, optional): Suffix of the files to load. Must be either "csv" or "parquet".
     """
-    if file_suffix is None:
-        file_suffix = "parquet"
     if file_suffix not in ["parquet", "csv"]:
         raise ValueError(
             f"file_suffix must be either 'parquet' or 'csv', got {file_suffix}",


### PR DESCRIPTION
File suffix was overwritten in a single function which messes things up if someone wants to use csv (for some reason)/for backwards compatibility

- [ ] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatability)

Fixes #[issue_nr_here].

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
