### PR TITLE
fix: remove shak_code + operator check

### DIFF
--- a/src/psycop_feature_generation/loaders/raw/load_admissions.py
+++ b/src/psycop_feature_generation/loaders/raw/load_admissions.py
@@ -27,11 +27,6 @@ def admissions(
         pd.DataFrame: Dataframe with all physical visits to psychiatry. Has columns dw_ek_borger, timestamp and value (length of admissions in days).
     """
 
-    if bool(shak_code) != bool(shak_sql_operator):
-        raise ValueError(
-            "shak_code and shak_sql_operator must both be set or both be None.",
-        )
-
     # SHAK = 6600 ≈ in psychiatry
     d = {
         "LPR3": {

--- a/src/psycop_feature_generation/loaders/raw/load_visits.py
+++ b/src/psycop_feature_generation/loaders/raw/load_visits.py
@@ -31,11 +31,6 @@ def physical_visits(
         pd.DataFrame: Dataframe with all physical visits to psychiatry. Has columns dw_ek_borger and timestamp.
     """
 
-    if bool(shak_code) != bool(shak_sql_operator):
-        raise ValueError(
-            "shak_code and shak_sql_operator must both be set or both be None.",
-        )
-
     # SHAK = 6600 ≈ in psychiatry
     d = {
         "LPR3": {


### PR DESCRIPTION

- [ ] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatability)

Fixes #70

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
