### PR TITLE
optional name for timestamp in prediction_times_df

### DIFF
--- a/src/psycop_feature_generation/application_modules/filter_prediction_times.py
+++ b/src/psycop_feature_generation/application_modules/filter_prediction_times.py
@@ -25,7 +25,7 @@ class PredictionTimeFilterer:
         Args:
             prediction_times_df (pd.DataFrame): Prediction times dataframe.
                 Should contain entity_id and timestamp columns with col_names matching those in project_info.col_names.
-            quarantine_df (pd.DataFrame, optional): A dataframe with "timestamp" column from which to start the quarantine.
+            quarantine_df (pd.DataFrame, optional): A dataframe with timestamp column from which to start the quarantine.
                 Any prediction times within the quarantine_interval_days after this timestamp will be dropped.
             quarantine_days (int, optional): Number of days to quarantine.
             entity_id_col_name (str): Name of the entity_id_col_name column.
@@ -37,6 +37,7 @@ class PredictionTimeFilterer:
         self.quarantine_days = quarantine_interval_days
         self.entity_id_col_name = entity_id_col_name
         self.timestamp_col_name = timestamp_col_name
+        self.quarantine_df.columns = [self.entity_id_col_name, "timestamp_quarantine"]
 
         self.added_pred_time_uuid_col: bool = False
         self.pred_time_uuid_col_name = "pred_time_uuid"
@@ -51,7 +52,7 @@ class PredictionTimeFilterer:
             ] = self.prediction_times_df[self.entity_id_col_name].astype(
                 str
             ) + self.prediction_times_df[
-                "timestamp"
+                timestamp_col_name
             ].dt.strftime(
                 "-%Y-%m-%d-%H-%M-%S",
             )
@@ -65,11 +66,10 @@ class PredictionTimeFilterer:
             self.quarantine_df,
             on=self.entity_id_col_name,
             how="left",
-            suffixes=("_pred", "_quarantine"),
         )
 
         df["days_since_quarantine"] = (
-            df["timestamp_pred"] - df["timestamp_quarantine"]
+            df[self.timestamp_col_name] - df["timestamp_quarantine"]
         ).dt.days
 
         # Check if the prediction time is hit by the quarantine date.
@@ -106,8 +106,6 @@ class PredictionTimeFilterer:
             ],
         )
 
-        # Rename the timestamp column
-        df = df.rename(columns={"timestamp_pred": "timestamp"})
 
         n_after = len(df)
         log.info(


### PR DESCRIPTION
Name for timestamp column was optional for prediction_times_df, but the function didn't run if the name wasn't '"timestamp". Tried to alter to manual "timestamp" names to self.timestamp_col_name, but then the code following the merge with quarantine_df broke, since the suffixes weren't added. So changed the name of the timestamp in quarantine_df in the start of the script.

- [ ] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatability)

Fixes #122 .

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
