### PR TITLE
changed timestamp to end date and adapted code

### DIFF
--- a/src/psycop_feature_generation/loaders/raw/load_coercion.py
+++ b/src/psycop_feature_generation/loaders/raw/load_coercion.py
@@ -32,7 +32,7 @@ def coercion_duration(
 
     view = "[FOR_tvang_alt_hele_kohorten_inkl_2021]"
 
-    sql = f"SELECT dw_ek_borger, datotid_start_sei, varighed_timer_sei, typetekst_sei FROM [fct].{view} WHERE datotid_start_sei IS NOT NULL AND typetekst_sei NOT IN {coercion_discard}"
+    sql = f"SELECT dw_ek_borger, datotid_start_sei, datotid_slut_sei, varighed_timer_sei, typetekst_sei FROM [fct].{view} WHERE datotid_start_sei IS NOT NULL AND typetekst_sei NOT IN {coercion_discard}"
 
     if coercion_type and reason_for_coercion is None:
 
@@ -48,18 +48,24 @@ def coercion_duration(
 
     df = sql_load(sql, database="USR_PS_FORSK", chunksize=None, n_rows=n_rows)
 
+    # add end time as start time for akut beroligende
+    df.loc[df.typetekst_sei == 'Beroligende medicin', 'datotid_slut_sei'] = df['datotid_start_sei']
+    
+    # drop nas for coercion end times
+    df = df.dropna(subset='datotid_slut_sei')
+
     # Drop duplicate rows
     df = df.drop_duplicates(keep="first")
 
     df.rename(
-        columns={"datotid_start_sei": "timestamp", "varighed_timer_sei": "value"},
+        columns={"datotid_slut_sei": "timestamp", "varighed_timer_sei": "value"},
         inplace=True,
     )
 
     # Change NaNs to 0
     df["value"].fillna(0, inplace=True)
 
-    return df.reset_index(drop=True)
+    return df[['dw_ek_borger', 'timestamp', 'value']].reset_index(drop=True)
 
 
 def _concatenate_coercion(

--- a/src/psycop_feature_generation/loaders/raw/load_coercion.py
+++ b/src/psycop_feature_generation/loaders/raw/load_coercion.py
@@ -48,7 +48,7 @@ def coercion_duration(
 
     df = sql_load(sql, database="USR_PS_FORSK", chunksize=None, n_rows=n_rows)
 
-    # add end time as start time for akut beroligende
+    # add end time as start time for acute sedation
     df.loc[df.typetekst_sei == 'Beroligende medicin', 'datotid_slut_sei'] = df['datotid_start_sei']
     
     # drop nas for coercion end times


### PR DESCRIPTION
Changed timestamp from start of coercion to end of coercion. For acute sedation there is no end time, so the end time is set to start time and the duration of coercion (value) is set to 0.

- [x] I have battle-tested on Overtaci (RMAPPS1279)
- [x] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatability)

Fixes #131.

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
