### PR TITLE
add skema 2 loader without nutrition and change to newest coercion data

### DIFF
--- a/src/psycop_feature_generation/loaders/raw/load_coercion.py
+++ b/src/psycop_feature_generation/loaders/raw/load_coercion.py
@@ -30,7 +30,7 @@ def coercion_duration(
     coercion_discard = """('Døraflåsning', 'Personlig afskærmning over 24 timer', 'Koordinationsplan',
     'Udskrivningsaftale', 'Særlige dørlåse', 'Personlige alarm- og pejlesystemer', 'Andet' )"""
 
-    view = "[FOR_tvang_alt_hele_kohorten_inkl_2021]"
+    view = "[FOR_tvang_alt_hele_kohorten_inkl_2021_feb2022]"
 
     sql = f"SELECT dw_ek_borger, datotid_start_sei, datotid_slut_sei, varighed_timer_sei, typetekst_sei FROM [fct].{view} WHERE datotid_start_sei IS NOT NULL AND typetekst_sei NOT IN {coercion_discard}"
 
@@ -200,6 +200,26 @@ def skema_2(n_rows: Optional[int] = None) -> pd.DataFrame:
         },
         {
             "coercion_type": "Ernæring",
+        },
+        {
+            "coercion_type": "ECT",
+        },
+    ]
+
+    return _concatenate_coercion(
+        coercion_types_list=coercion_types_list,
+        n_rows=n_rows,
+    )
+
+
+@data_loaders.register("skema_2_without_nutrition")
+def skema_2_without_nutrition(n_rows: Optional[int] = None) -> pd.DataFrame:
+    coercion_types_list = [
+        {
+            "coercion_type": "Af legemlig lidelse",
+        },
+        {
+            "coercion_type": "Medicinering",
         },
         {
             "coercion_type": "ECT",


### PR DESCRIPTION
- [X] I have battle-tested on Overtaci (RMAPPS1279)

## Notes for reviewers
One new loader added: skema_2_without_nutrition. 
Changed coercion data to include feb2022.