### PR TITLE
fix: quarantine_df and quarantine_days can be left as None

### DIFF
--- a/src/psycop_feature_generation/application_modules/filter_prediction_times.py
+++ b/src/psycop_feature_generation/application_modules/filter_prediction_times.py
@@ -31,13 +31,21 @@ class PredictionTimeFilterer:
             entity_id_col_name (str): Name of the entity_id_col_name column.
             timestamp_col_name (str, optional): Name of the timestamp column.
         """
-
         self.prediction_times_df = prediction_times_df
+
         self.quarantine_df = quarantine_timestamps_df
         self.quarantine_days = quarantine_interval_days
-        self.quarantine_df = self.quarantine_df.rename(
-            columns={"timestamp": "timestamp_quarantine"},
-        )
+
+        if all(v is None for v in (self.quarantine_days, self.quarantine_df)):
+            raise ValueError(
+                "If either of quarantine_df and quarantine_days are provided, both must be provided.",
+            )
+
+        if self.quarantine_df is not None and self.quarantine_days is not None:
+            self.quarantine_df = self.quarantine_df.rename(
+                columns={"timestamp": "timestamp_quarantine"},
+            )
+
         self.entity_id_col_name = entity_id_col_name
         self.timestamp_col_name = timestamp_col_name
 
@@ -120,11 +128,6 @@ class PredictionTimeFilterer:
         df = self.prediction_times_df
 
         if self.quarantine_df is not None or self.quarantine_days is not None:
-            if all([v is None for v in (self.quarantine_days, self.quarantine_df)]):
-                raise ValueError(
-                    "If either of quarantine_df and quarantine_days are provided, both must be provided.",
-                )
-
             df = self._filter_prediction_times_by_quarantine_period()
 
         if self.added_pred_time_uuid_col:

--- a/src/psycop_feature_generation/application_modules/flatten_dataset.py
+++ b/src/psycop_feature_generation/application_modules/flatten_dataset.py
@@ -53,7 +53,7 @@ def filter_prediction_times(
 @wandb_alert_on_exception
 def create_flattened_dataset(
     feature_specs: list[_AnySpec],
-    filtered_prediction_times_df: pd.DataFrame,
+    prediction_times_df: pd.DataFrame,
     drop_pred_times_with_insufficient_look_distance: bool,
     project_info: ProjectInfo,
     quarantine_df: Optional[pd.DataFrame] = None,
@@ -76,7 +76,7 @@ def create_flattened_dataset(
     """
 
     filtered_prediction_times_df = filter_prediction_times(
-        prediction_times_df=filtered_prediction_times_df,
+        prediction_times_df=prediction_times_df,
         project_info=project_info,
         quarantine_df=quarantine_df,
         quarantine_days=quarantine_days,

--- a/src/psycop_feature_generation/application_modules/flatten_dataset.py
+++ b/src/psycop_feature_generation/application_modules/flatten_dataset.py
@@ -53,7 +53,7 @@ def filter_prediction_times(
 @wandb_alert_on_exception
 def create_flattened_dataset(
     feature_specs: list[_AnySpec],
-    prediction_times_df: pd.DataFrame,
+    filtered_prediction_times_df: pd.DataFrame,
     drop_pred_times_with_insufficient_look_distance: bool,
     project_info: ProjectInfo,
     quarantine_df: Optional[pd.DataFrame] = None,
@@ -75,16 +75,15 @@ def create_flattened_dataset(
         FlattenedDataset: Flattened dataset.
     """
 
-    if quarantine_df or quarantine_days:
-        prediction_times_df = filter_prediction_times(
-            prediction_times_df=prediction_times_df,
-            project_info=project_info,
-            quarantine_df=quarantine_df,
-            quarantine_days=quarantine_days,
-        )
+    filtered_prediction_times_df = filter_prediction_times(
+        prediction_times_df=filtered_prediction_times_df,
+        project_info=project_info,
+        quarantine_df=quarantine_df,
+        quarantine_days=quarantine_days,
+    )
 
     flattened_dataset = TimeseriesFlattener(
-        prediction_times_df=prediction_times_df,
+        prediction_times_df=filtered_prediction_times_df,
         n_workers=min(
             len(feature_specs),
             psutil.cpu_count(logical=True),

--- a/src/psycop_feature_generation/application_modules/flatten_dataset.py
+++ b/src/psycop_feature_generation/application_modules/flatten_dataset.py
@@ -74,15 +74,17 @@ def create_flattened_dataset(
     Returns:
         FlattenedDataset: Flattened dataset.
     """
-    filtered_prediction_times_df = filter_prediction_times(
-        prediction_times_df=prediction_times_df,
-        project_info=project_info,
-        quarantine_df=quarantine_df,
-        quarantine_days=quarantine_days,
-    )
+
+    if quarantine_df or quarantine_days:
+        prediction_times_df = filter_prediction_times(
+            prediction_times_df=prediction_times_df,
+            project_info=project_info,
+            quarantine_df=quarantine_df,
+            quarantine_days=quarantine_days,
+        )
 
     flattened_dataset = TimeseriesFlattener(
-        prediction_times_df=filtered_prediction_times_df,
+        prediction_times_df=prediction_times_df,
         n_workers=min(
             len(feature_specs),
             psutil.cpu_count(logical=True),


### PR DESCRIPTION
- [x] I have battle-tested on Overtaci (RMAPPS1279)

Fixes #151 .

## Notes for reviewers
should fix so code doesn't break when quarantine_df and quarantine_days are not supplied for the create_flattened_dataset function.
quarantine_days and quarantine_df are also optional in the PredictionTimeFilterer class. maybe change to not optional?
