### PR TITLE
feat: re-implement feature descriptive stats html table

### DIFF
--- a/src/psycop_feature_generation/application_modules/describe_flattened_dataset.py
+++ b/src/psycop_feature_generation/application_modules/describe_flattened_dataset.py
@@ -1,12 +1,7 @@
 """Describe flattened dataset.""" ""
-from collections.abc import Iterable
 import logging
+from collections.abc import Iterable
 from typing import Union
-
-from timeseriesflattener.feature_spec_objects import (
-    StaticSpec,
-    TemporalSpec,
-)
 
 from psycop_feature_generation.application_modules.project_setup import ProjectInfo
 from psycop_feature_generation.application_modules.wandb_utils import (
@@ -18,6 +13,8 @@ from psycop_feature_generation.data_checks.flattened.data_integrity import (
 from psycop_feature_generation.data_checks.flattened.feature_describer import (
     save_feature_descriptive_stats_from_dir,
 )
+
+from timeseriesflattener.feature_spec_objects import StaticSpec, TemporalSpec
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +46,7 @@ def save_flattened_dataset_description_to_disk(
     )
 
     save_feature_descriptive_stats_from_dir(
-        fearture_set_dir=project_info.feature_set_path, 
+        feature_set_dir=project_info.feature_set_path, 
         feature_specs=feature_specs,
         file_suffix=".parquet",
     )

--- a/src/psycop_feature_generation/application_modules/describe_flattened_dataset.py
+++ b/src/psycop_feature_generation/application_modules/describe_flattened_dataset.py
@@ -26,7 +26,7 @@ def save_flattened_dataset_description_to_disk(
     splits: Iterable[str] = ("train", "val", "test"),
     compare_splits: bool = True,
 ):
-    """Describe output. Runs and saves train data integrity checks, split pair integrity checks, outcome integrity checks and a html table containing descriptive statistics for each feature.
+    """Describe and check flattened dataset. Runs and saves train data integrity checks, split pair integrity checks, outcome integrity checks and a html table containing descriptive statistics for each feature.
 
 
     Args:

--- a/src/psycop_feature_generation/application_modules/describe_flattened_dataset.py
+++ b/src/psycop_feature_generation/application_modules/describe_flattened_dataset.py
@@ -1,12 +1,22 @@
 """Describe flattened dataset.""" ""
+from collections.abc import Iterable
 import logging
+from typing import Union
+
+from timeseriesflattener.feature_spec_objects import (
+    StaticSpec,
+    TemporalSpec,
+)
 
 from psycop_feature_generation.application_modules.project_setup import ProjectInfo
 from psycop_feature_generation.application_modules.wandb_utils import (
     wandb_alert_on_exception,
 )
 from psycop_feature_generation.data_checks.flattened.data_integrity import (
-    save_feature_set_integrity_from_dir,
+    save_feature_set_integrity_checks_from_dir,
+)
+from psycop_feature_generation.data_checks.flattened.feature_describer import (
+    save_feature_descriptive_stats_from_dir,
 )
 
 log = logging.getLogger(__name__)
@@ -15,48 +25,39 @@ log = logging.getLogger(__name__)
 @wandb_alert_on_exception
 def save_flattened_dataset_description_to_disk(
     project_info: ProjectInfo,
-    describe_splits: bool = True,
+    feature_specs: list[Union[TemporalSpec, StaticSpec]],
+    splits: Iterable[str] = ("train", "val", "test"),
     compare_splits: bool = True,
 ):
-    """Describe output.
+    """Describe output. Runs and saves train data integrity checks, split pair integrity checks, outcome integrity checks and a html table containing descriptive statistics for each feature.
+
 
     Args:
         project_info (ProjectInfo): Project info
-        describe_splits (bool, optional): Whether to describe each split. Defaults to True.
+        splits (Iterable[str], optional): Splits to include in the integrity checks. Defaults to ("train", "val", "test").
         compare_splits (bool, optional): Whether to compare splits, e.g. do all categories exist in both train and val. Defaults to True.
     """
-    feature_set_description_path = (
-        project_info.feature_set_path / "feature_set_description"
+    feature_set_descriptive_stats_path = (
+        project_info.feature_set_path / "feature_set_descriptive_stats"
     )
-    split_feature_distribution_comparison_path = (
-        project_info.feature_set_path / "split_feature_distribution_comparison_path"
+    data_integrity_checks_path = (
+        project_info.feature_set_path / "data_integrity_checks"
     )
 
     log.info(
-        f"Saving flattened dataset description to disk. Check {feature_set_description_path} and {split_feature_distribution_comparison_path} to validate that your dataset is not broken in some way.",
+        f"Saving flattened dataset descriptions to disk. Check {feature_set_descriptive_stats_path} and {data_integrity_checks_path} to view data set descriptions and validate that your dataset is not broken in some way.",
     )
 
-    for method in ("describe", "compare"):
-        # Describe the feature set
-        if method == "describe" and describe_splits:
-            splits = ["train"]
+    save_feature_descriptive_stats_from_dir(
+        fearture_set_dir=project_info.feature_set_path, 
+        feature_specs=feature_specs,
+        file_suffix=".parquet",
+    )
 
-            compare_splits_in_method = False
-            out_dir = feature_set_description_path
-
-        # Compare train, val and test, to make sure they have the same categories
-        if method == "compare" and compare_splits:
-            splits = ["train", "val", "test"]
-
-            # Don't describe specs in comparison, to avoid leakage by describing features in val and test
-            compare_splits_in_method = True
-            out_dir = split_feature_distribution_comparison_path
-
-        save_feature_set_integrity_from_dir(
-            splits=splits,
-            out_dir=out_dir,
-            dataset_format=project_info.dataset_format,
-            describe_splits=describe_splits,
-            compare_splits=compare_splits_in_method,
-            feature_set_dir=project_info.feature_set_path,
-        )
+    save_feature_set_integrity_checks_from_dir(
+        feature_set_dir=project_info.feature_set_path,
+        splits=splits,
+        out_dir=data_integrity_checks_path,
+        dataset_format=project_info.dataset_format,
+        compare_splits=compare_splits,
+    )

--- a/src/psycop_feature_generation/data_checks/flattened/feature_describer.py
+++ b/src/psycop_feature_generation/data_checks/flattened/feature_describer.py
@@ -210,8 +210,7 @@ def save_feature_descriptive_stats_from_dir(
     if out_dir is None:
         out_dir = feature_set_dir / "feature_set_descriptive_stats"
 
-    if not out_dir.exists():
-        out_dir.mkdir()
+    out_dir.mkdir(exists_ok=True, parents=True)
 
     for split in splits:
         msg.info(f"{split}: Creating descriptive stats for feature set")

--- a/src/psycop_feature_generation/data_checks/flattened/feature_describer.py
+++ b/src/psycop_feature_generation/data_checks/flattened/feature_describer.py
@@ -189,14 +189,14 @@ def generate_feature_description_df(
     return feature_description_df
 
 
-def save_feature_description_from_dir(
+def save_feature_descriptive_stats_from_dir(
     feature_set_dir: Path,
     feature_specs: list[Union[TemporalSpec, StaticSpec]],
     file_suffix: str,
     splits: Sequence[str] = ("train",),
     out_dir: Path = None,
 ):
-    """Write a csv with feature descriptions in the directory.
+    """Write a html table and csv with descriptive stats for features in the directory.
 
     Args:
         feature_set_dir (Path): Path to directory with data frames.
@@ -208,16 +208,13 @@ def save_feature_description_from_dir(
     msg = Printer(timestamp=True)
 
     if out_dir is None:
-        save_dir = feature_set_dir / "feature_descriptions"
+        out_dir = feature_set_dir / "feature_set_descriptive_stats"
 
-    else:
-        save_dir = out_dir / "feature_descriptions"
-
-    if not save_dir.exists():
-        save_dir.mkdir()
+    if not out_dir.exists():
+        out_dir.mkdir()
 
     for split in splits:
-        msg.info(f"{split}: Creating feature description")
+        msg.info(f"{split}: Creating descriptive stats for feature set")
 
         predictors = load_split_predictors(
             feature_set_dir=feature_set_dir,
@@ -226,22 +223,22 @@ def save_feature_description_from_dir(
             file_suffix=file_suffix,
         )
 
-        msg.info(f"{split}: Generating feature description dataframe")
+        msg.info(f"{split}: Generating descriptive stats dataframe")
 
-        feature_description_df = generate_feature_description_df(
+        feature_descriptive_stats = generate_feature_description_df(
             df=predictors,
             predictor_specs=feature_specs,
         )
 
-        msg.info(f"{split}: Writing feature description to disk")
+        msg.info(f"{split}: Writing descriptive stats dataframe to disk")
 
-        feature_description_df.to_csv(
-            save_dir / f"{split}_feature_description.csv",
+        feature_descriptive_stats.to_csv(
+            out_dir / f"{split}_feature_descriptive_stats.csv",
             index=False,
         )
         # Writing html table as well
         save_df_to_pretty_html_table(
-            path=save_dir / f"{split}_feature_description.html",
-            title="Feature description",
-            df=feature_description_df,
+            path=out_dir / f"{split}_feature_descriptive_stats.html",
+            title="Feature descriptive stats",
+            df=feature_descriptive_stats,
         )


### PR DESCRIPTION
- [x] I have battle-tested on Overtaci (RMAPPS1279)


Fixes #156

## Notes for reviewers
Re-implemented the generation of a HTML table/dataframe containing feature descriptions. Also changed how data integrity checks are  saved. 
On overtaci, see _E:\shared_resources\forced_admissions\feature_sets\psycop_forced_admissions_adminjakdam_features_2023_02_13_16_32_ folder for new implementation
See _E:\shared_resources\forced_admissions\feature_sets\psycop_forced_admissions_adminjakdam_features_2023_01_03_10_20_ for old implementation (without outcome integrity checks) 
