### PR TITLE
feat: enable using start or end times when loading physical visits

### DIFF
--- a/src/psycop_feature_generation/loaders/example/load_physical_visits.py
+++ b/src/psycop_feature_generation/loaders/example/load_physical_visits.py
@@ -1,11 +1,9 @@
 """Example loader for physical visits."""
+from tracemalloc import start
+
 import psycop_feature_generation.loaders.raw as r
 
 if __name__ == "__main__":
-    psych_with_length = r.load_visits.physical_visits_loader(
-        return_value_as_visit_length_days=True
-    )
-
     psych = r.load_visits.physical_visits_to_psychiatry(timestamps_only=True)
     somatic = r.load_visits.physical_visits_to_somatic(n_rows=1000)
 

--- a/src/psycop_feature_generation/loaders/example/load_physical_visits.py
+++ b/src/psycop_feature_generation/loaders/example/load_physical_visits.py
@@ -2,6 +2,12 @@
 import psycop_feature_generation.loaders.raw as r
 
 if __name__ == "__main__":
-    df = r.load_visits.physical_visits(n_rows=1000)
-    psych = r.load_visits.physical_visits_to_psychiatry(n_rows=1000)
+    psych_with_length = r.load_visits.physical_visits_loader(
+        return_value_as_visit_length_days=True
+    )
+
+    psych = r.load_visits.physical_visits_to_psychiatry(timestamps_only=True)
     somatic = r.load_visits.physical_visits_to_somatic(n_rows=1000)
+
+    print(f"Max date is {psych['timestamp'].max()}")
+    pass

--- a/src/psycop_feature_generation/loaders/raw/load_visits.py
+++ b/src/psycop_feature_generation/loaders/raw/load_visits.py
@@ -31,6 +31,7 @@ class RawValueSourceSchema(BaseModel):
 
 
 def physical_visits(
+    timestamp_for_output: Literal["start", "end"] = "end",
     shak_code: Optional[int] = None,
     shak_sql_operator: Optional[str] = "=",
     where_clause: Optional[str] = None,
@@ -40,11 +41,11 @@ def physical_visits(
     visit_types: Optional[
         list[Literal["admissions", "ambulatory_visits", "emergency_visits"]]
     ] = None,
-    timestamp_for_output: Literal["start", "end"] = "end",
 ) -> pd.DataFrame:
     """Load pshysical visits to both somatic and psychiatry.
 
     Args:
+        timestamp_for_output (Literal["start", "end"], optional): Whether to use the start or end timestamp for the output. Defaults to "end".
         shak_code (Optional[int], optional): SHAK code indicating where to keep/not keep visits from (e.g. 6600). Combines with
             shak_sql_operator, e.g. "!= 6600". Defaults to None, in which case all admissions are kept.
         shak_sql_operator (Optional[str], optional): Operator to use with shak_code. Defaults to "=".
@@ -53,7 +54,6 @@ def physical_visits(
         n_rows (Optional[int], optional): Number of rows to return. Defaults to None.
         return_value_as_visit_length_days (Optional[bool], optional): Whether to return length of visit in days as the value for the loader. Defaults to False which results in value=1 for all visits.
         visit_types (Optional[list[Literal["admissions", "ambulatory_visits", "emergency_visits"]]], optional): Whether to subset visits by visit types. Defaults to None.
-        timestamp_for_output (Literal["start", "end"], optional): Whether to use the start or end timestamp for the output. Defaults to "end".
 
     Returns:
         pd.DataFrame: Dataframe with all physical visits to psychiatry. Has columns dw_ek_borger and timestamp.
@@ -161,9 +161,11 @@ def physical_visits(
 
     log.info("Loaded physical visits")
 
-    return output_df[["dw_ek_borger", timestamp_for_output, "value"]].reset_index(
-        drop=True
+    output_df.rename(
+        columns={f"timestamp_{timestamp_for_output}": "timestamp"}, inplace=True
     )
+
+    return output_df[["dw_ek_borger", f"timestamp", "value"]].reset_index(drop=True)
 
 
 @data_loaders.register("physical_visits")

--- a/src/psycop_feature_generation/loaders/raw/load_visits.py
+++ b/src/psycop_feature_generation/loaders/raw/load_visits.py
@@ -4,10 +4,10 @@ import logging
 from typing import Literal, Optional
 
 import pandas as pd
-from timeseriesflattener.feature_spec_objects import BaseModel
 
 from psycop_feature_generation.loaders.raw.sql_load import sql_load
 from psycop_feature_generation.utils import data_loaders
+from timeseriesflattener.feature_spec_objects import BaseModel
 
 log = logging.getLogger(__name__)
 
@@ -182,7 +182,7 @@ def physical_visits_to_psychiatry(
     n_rows: Optional[int] = None,
     timestamps_only: bool = False,
     return_value_as_visit_length_days: Optional[bool] = True,
-    timestamp_for_output: str = "start",
+    timestamp_for_output: Literal["start", "end"] = "start",
 ) -> pd.DataFrame:
     """Load physical visits to psychiatry."""
     df = physical_visits(

--- a/src/psycop_feature_generation/loaders/raw/load_visits.py
+++ b/src/psycop_feature_generation/loaders/raw/load_visits.py
@@ -163,7 +163,9 @@ def physical_visits(
     )
 
     # Keep only one visit per timestamp
-    df = df.drop_duplicates(subset=["dw_ek_borger", "timestamp"], keep="first")
+    output_df = output_df.drop_duplicates(
+        subset=["dw_ek_borger", "timestamp"], keep="first"
+    )
 
     return output_df[["dw_ek_borger", f"timestamp", "value"]].reset_index(drop=True)
 

--- a/src/psycop_feature_generation/loaders/raw/load_visits.py
+++ b/src/psycop_feature_generation/loaders/raw/load_visits.py
@@ -4,10 +4,10 @@ import logging
 from typing import Literal, Optional
 
 import pandas as pd
+from timeseriesflattener.feature_spec_objects import BaseModel
 
 from psycop_feature_generation.loaders.raw.sql_load import sql_load
 from psycop_feature_generation.utils import data_loaders
-from timeseriesflattener.feature_spec_objects import BaseModel
 
 log = logging.getLogger(__name__)
 
@@ -161,6 +161,9 @@ def physical_visits(
     output_df.rename(
         columns={f"timestamp_{timestamp_for_output}": "timestamp"}, inplace=True
     )
+
+    # Keep only one visit per timestamp
+    df = df.drop_duplicates(subset=["dw_ek_borger", "timestamp"], keep="first")
 
     return output_df[["dw_ek_borger", f"timestamp", "value"]].reset_index(drop=True)
 


### PR DESCRIPTION
## Notes for reviewers
Had some problems where the "end" of my dataset appeared to be in 2111, meaning that no prediction times were marked as having insufficient lookahead. To fix this, I need to use the start of a visit as my prediction time - and that was hard to do the way the code looked before. This should enable more flexibility.

I also refactored a bit, I think this makes the code easier to read :-)

* Filter visits so we only load the physical ones
* Adds an option for whether to use start or end timestamps when loading physical visits
* Uses start timestamps by default when loading physical visits to psychiatry

Let me know what you think!